### PR TITLE
Introduce APIResult and Revamp Response Codes

### DIFF
--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/Application.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/Application.kt
@@ -12,8 +12,8 @@ import com.rohengiralt.minecraftservermanager.domain.model.runner.local.serverja
 import com.rohengiralt.minecraftservermanager.domain.model.runner.local.serverjar.MinecraftServerJarFactory
 import com.rohengiralt.minecraftservermanager.domain.model.runner.local.serverjar.MinecraftServerJarResourceManager
 import com.rohengiralt.minecraftservermanager.domain.repository.*
-import com.rohengiralt.minecraftservermanager.domain.service.RestAPIService
-import com.rohengiralt.minecraftservermanager.domain.service.RestAPIServiceImpl
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIServiceImpl
 import com.rohengiralt.minecraftservermanager.domain.service.WebsocketAPIService
 import com.rohengiralt.minecraftservermanager.domain.service.WebsocketAPIServiceImpl
 import com.rohengiralt.minecraftservermanager.plugins.configureMonitoring

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/model/runner/MinecraftServerRunner.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/model/runner/MinecraftServerRunner.kt
@@ -41,7 +41,7 @@ interface MinecraftServerRunner {
      * Prepares the environment to run the given server, and then runs the server.
      * @param server the server to run
      * @param environmentOverrides additional configuration to specify how the server is run
-     * @return a record representing the new run of [server]
+     * @return a record representing the new run of [server], or null if running failed.
      */
     suspend fun runServer(
         server: MinecraftServer,
@@ -49,10 +49,11 @@ interface MinecraftServerRunner {
     ): MinecraftServerCurrentRun?
 
     /**
-     * Stops the provided run if it exists.
+     * Stops the provided run.
      * Note that this method may suspend until the run has been successfully ended.
      * @param uuid the UUID of the run to stop
-     * @return true if a run was ended (if no run with the provided uuid exists, returns false)
+     * @return true if the run was ended
+     * @throws IllegalArgumentException if no run exists with the UUID [uuid].
      */
     suspend fun stopRun(uuid: UUID): Boolean
 
@@ -60,8 +61,8 @@ interface MinecraftServerRunner {
      * Stops the provided server's run if one exists.
      * Note that this method may suspend until the run has been successfully ended.
      * @param serverUUID the UUID of the server whose run to stop
-     * @return true if a run was ended
-     * (if no server exists with the provided uuid and/or the server is already stopped, returns false)
+     * @return true if the run is stopped.
+     *         Returns true even if the server was already stopped before this method.
      */
     suspend fun stopRunByServer(serverUUID: UUID): Boolean
 

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/model/runner/local/LocalMinecraftServerRunner.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/model/runner/local/LocalMinecraftServerRunner.kt
@@ -81,12 +81,9 @@ object LocalMinecraftServerRunner : MinecraftServerRunner, KoinComponent {
                     )
                 }
 
-            if (pastRunRepository.savePastRuns(runsToArchive)) {
-                logger.info("Archived ${runsToArchive.size} left over current run(s)")
-                currentRunRecordRepository.removeAllRecords()
-            } else {
-                logger.error("Failed to archive left over current run(s)")
-            }
+            pastRunRepository.savePastRuns(runsToArchive)
+            logger.info("Archived ${runsToArchive.size} left over current run(s)")
+            currentRunRecordRepository.removeAllRecords()
         } catch (e: Throwable) {
             logger.error("Failed to archive left over current run(s), got error: {}", e.message)
         }
@@ -277,21 +274,16 @@ object LocalMinecraftServerRunner : MinecraftServerRunner, KoinComponent {
         currentRunRecordRepository.removeRecord(run.uuid)
 
         logger.trace("Removed current run {}, about to save past run", run.uuid)
-        val success: Boolean = try {
+        try {
             logger.trace("Converting run to past run")
             val pastRun = run.toPastRun(endTime)
             logger.trace("Saving past run")
             pastRunRepository.savePastRun(pastRun)
         } catch (e: Throwable) {
             logger.error("Error archiving past run: $e")
-            false
         }
 
-        if (success) {
-            logger.trace("Successfully archived run {}", run.uuid)
-        } else {
-            logger.error("Couldn't archive run ${run.uuid}")
-        }
+        logger.trace("Successfully archived run {}", run.uuid)
     }
 
     private suspend fun MinecraftServerProcess.waitForEnd() {

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/DatabaseMinecraftServerPastRunRepository.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/DatabaseMinecraftServerPastRunRepository.kt
@@ -1,17 +1,21 @@
 package com.rohengiralt.minecraftservermanager.domain.repository
 
 import com.rohengiralt.minecraftservermanager.domain.model.run.MinecraftServerPastRun
+import com.rohengiralt.minecraftservermanager.domain.repository.MinecraftServerPastRunTable.uuid
 import com.rohengiralt.minecraftservermanager.util.extensions.exposed.jsonb
 import com.rohengiralt.minecraftservermanager.util.extensions.exposed.upsert
-import kotlinx.datetime.*
+import com.rohengiralt.minecraftservermanager.util.sql.ioExnTransaction
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toJavaLocalDateTime
+import kotlinx.datetime.toKotlinInstant
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.`java-time`.datetime
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
-import java.sql.SQLException
 import java.time.ZoneOffset
 import java.util.*
 
@@ -22,7 +26,7 @@ class DatabaseMinecraftServerPastRunRepository : MinecraftServerPastRunRepositor
         }
     }
 
-    override fun getPastRun(uuid: UUID): MinecraftServerPastRun? = transaction {
+    override fun getPastRun(uuid: UUID): MinecraftServerPastRun? = ioExnTransaction {
         MinecraftServerPastRunTable.select {
             MinecraftServerPastRunTable.uuid eq uuid
         }
@@ -33,11 +37,8 @@ class DatabaseMinecraftServerPastRunRepository : MinecraftServerPastRunRepositor
     override fun getAllPastRuns( //TODO: Return with most recent first
         serverUUID: UUID?,
         runnerUUID: UUID?
-    ): List<MinecraftServerPastRun> = transaction {
-        MinecraftServerPastRunTable.select {
-            (serverUUID?.let { matchingServer(it) } ?: Op.TRUE) and
-                    (runnerUUID?.let { matchingRun(it) } ?: Op.TRUE)
-        }
+    ): List<MinecraftServerPastRun> = ioExnTransaction {
+        MinecraftServerPastRunTable.select { serverFilter(serverUUID) and runnerFilter(runnerUUID) }
             .map {
                 with(MinecraftServerPastRunTable) {
                     MinecraftServerPastRun(
@@ -52,41 +53,41 @@ class DatabaseMinecraftServerPastRunRepository : MinecraftServerPastRunRepositor
             }
     }
 
-    private fun SqlExpressionBuilder.matchingServer(uuid: UUID) =
-        MinecraftServerPastRunTable.serverId eq uuid
-
-    private fun SqlExpressionBuilder.matchingRun(uuid: UUID) =
-        MinecraftServerPastRunTable.runnerId eq uuid
-
-    override fun savePastRun(run: MinecraftServerPastRun): Boolean = with(MinecraftServerPastRunTable) {
-        logger.debug("Saving past run ${run.uuid}")
-        try {
-            transaction {
-                MinecraftServerPastRunTable.upsert(uuid) { // TODO: Should be insert instead of upsert?
-                    it[uuid] = run.uuid
-                    it[serverId] = run.serverUUID
-                    it[runnerId] = run.runnerUUID
-                    it[start] = run.startTime.toLocalDateTime(TimeZone.UTC).toJavaLocalDateTime()
-                    it[stop] = run.stopTime?.toLocalDateTime(TimeZone.UTC)?.toJavaLocalDateTime()
-                    it[log] = run.log
-                }
-            }
-            logger.info("Successfully saved past run ${run.uuid}")
-            true
-        } catch (e: SQLException) {
-            logger.error("Encountered error saving past run ${run.uuid}: $e")
-            false
-        } catch (e: DateTimeArithmeticException) {
-            logger.error("Encountered error saving past run ${run.uuid}: $e")
-            false
-        } catch (e: Throwable) {
-            logger.error("Encountered error saving past run ${run.uuid}: $e")
-            false
-        }
+    /**
+     * Returns a SQL operator that is true if a server has UUID [serverUUID],
+     * or, if [serverUUID] is null, a filter that matches all servers.
+     */
+    private fun serverFilter(serverUUID: UUID?): Op<Boolean> {
+        return if (serverUUID != null) {
+            MinecraftServerPastRunTable.serverId eq serverUUID
+        } else Op.TRUE // No filter
     }
 
-    override fun savePastRuns(runs: Iterable<MinecraftServerPastRun>): Boolean =
-        runs.all(::savePastRun) // TODO: Database operation instead
+    /**
+     * Returns a SQL operator that is true if a server has UUID [runnerUUID],
+     * or, if [runnerUUID] is null, a filter that matches all servers.
+     */
+    private fun runnerFilter(runnerUUID: UUID?) = if (runnerUUID != null) {
+        MinecraftServerPastRunTable.runnerId eq runnerUUID
+    } else Op.TRUE // No filter
+
+    override fun savePastRun(run: MinecraftServerPastRun) {
+        logger.debug("Saving past run {}", run.uuid)
+        ioExnTransaction {
+            MinecraftServerPastRunTable.upsert(uuid) { // TODO: Should be insert instead of upsert?
+                it[uuid] = run.uuid
+                it[serverId] = run.serverUUID
+                it[runnerId] = run.runnerUUID
+                it[start] = run.startTime.toLocalDateTime(TimeZone.UTC).toJavaLocalDateTime()
+                it[stop] = run.stopTime?.toLocalDateTime(TimeZone.UTC)?.toJavaLocalDateTime()
+                it[log] = run.log
+            }
+        }
+        logger.info("Successfully saved past run ${run.uuid}")
+    }
+
+    override fun savePastRuns(runs: Iterable<MinecraftServerPastRun>) =
+        runs.forEach(::savePastRun) // TODO: Database operation instead
 
     private fun ResultRow.toServerPastRun(): MinecraftServerPastRun = with(MinecraftServerPastRunTable) {
         MinecraftServerPastRun(

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerPastRunRepository.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerPastRunRepository.kt
@@ -1,11 +1,34 @@
 package com.rohengiralt.minecraftservermanager.domain.repository
 
 import com.rohengiralt.minecraftservermanager.domain.model.run.MinecraftServerPastRun
+import io.ktor.utils.io.errors.*
 import java.util.*
 
 interface MinecraftServerPastRunRepository {
+    /**
+     * Gets a single past run by its UUID
+     * @return the run with UUID [uuid], or null if none found
+     * @throws IOException if retrieval fails
+     */
     fun getPastRun(uuid: UUID): MinecraftServerPastRun?
+
+    /**
+     * Gets all of the past runs stored in this repository, optionally filtered by server or runner UUID.
+     * @param serverUUID the server to filter by, or none if not to filter by server
+     * @param runnerUUID the runner to filter by, or none if not to filter by runner
+     * @throws IOException if retrieval fails
+     */
     fun getAllPastRuns(serverUUID: UUID? = null, runnerUUID: UUID? = null): List<MinecraftServerPastRun>
-    fun savePastRun(run: MinecraftServerPastRun): Boolean
-    fun savePastRuns(runs: Iterable<MinecraftServerPastRun>): Boolean
+
+    /**
+     * Stores a past run into the repository, possibly overwriting another run with the same UUID.
+     * @throws IOException if saving fails
+     */
+    fun savePastRun(run: MinecraftServerPastRun)
+
+    /**
+     * Stores several past runs into the repository, possibly overwriting others with the same UUID.
+     * @throws IOException if saving fails
+     */
+    fun savePastRuns(runs: Iterable<MinecraftServerPastRun>)
 }

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRepository.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRepository.kt
@@ -1,6 +1,7 @@
 package com.rohengiralt.minecraftservermanager.domain.repository
 
 import com.rohengiralt.minecraftservermanager.domain.model.server.MinecraftServer
+import io.ktor.utils.io.errors.*
 import kotlinx.coroutines.flow.StateFlow
 import java.util.*
 
@@ -24,7 +25,7 @@ interface MinecraftServerRepository {
      * Expects that no server with the same `uuid` is already in the repository; if so, does nothing.
      * @return true if the server was successfully added,
      *         false if a server with the same uuid was already in the repository.
-     * @throws Exception if adding fails for any reason other than duplicate
+     * @throws IOException if adding fails for any reason other than duplicate
      */
     fun addServer(minecraftServer: MinecraftServer): Boolean
 
@@ -37,7 +38,7 @@ interface MinecraftServerRepository {
     /**
      * Removes the server with uuid [uuid] from the repository, if such a server exists.
      * @return true if a server was successfully removed; false if no server with uuid [uuid] exists.
-     * @throws Exception if deletion fails for any reason other than not being present
+     * @throws IOException if deletion fails for any reason other than not being present
      */
     fun removeServer(uuid: UUID): Boolean
 

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRepository.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRepository.kt
@@ -1,7 +1,6 @@
 package com.rohengiralt.minecraftservermanager.domain.repository
 
 import com.rohengiralt.minecraftservermanager.domain.model.server.MinecraftServer
-import io.ktor.utils.io.errors.*
 import kotlinx.coroutines.flow.StateFlow
 import java.util.*
 
@@ -25,21 +24,20 @@ interface MinecraftServerRepository {
      * Expects that no server with the same `uuid` is already in the repository; if so, does nothing.
      * @return true if the server was successfully added,
      *         false if a server with the same uuid was already in the repository.
-     * @throws IOException if adding fails for any reason other than duplicate
+     * @throws Exception if adding fails for any reason other than duplicate
      */
     fun addServer(minecraftServer: MinecraftServer): Boolean
 
     /**
      * Saves the server [minecraftServer] to the repository.
      * If a server with the same `uuid` is already in the repository, replaces it with [minecraftServer].
-     * @return true if the server was successfully saved, including if another server was overwritten; false otherwise.
      */
-    fun saveServer(minecraftServer: MinecraftServer): Boolean
+    fun saveServer(minecraftServer: MinecraftServer)
 
     /**
      * Removes the server with uuid [uuid] from the repository, if such a server exists.
-     * @return true if a server was successfully removed; false otherwise.
-     *              Returns false if no server with uuid [uuid] exists.
+     * @return true if a server was successfully removed; false if no server with uuid [uuid] exists.
+     * @throws Exception if deletion fails for any reason other than not being present
      */
     fun removeServer(uuid: UUID): Boolean
 

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRepository.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRepository.kt
@@ -1,6 +1,7 @@
 package com.rohengiralt.minecraftservermanager.domain.repository
 
 import com.rohengiralt.minecraftservermanager.domain.model.server.MinecraftServer
+import io.ktor.utils.io.errors.*
 import kotlinx.coroutines.flow.StateFlow
 import java.util.*
 
@@ -22,8 +23,9 @@ interface MinecraftServerRepository {
     /**
      * Adds the server [minecraftServer] to the repository.
      * Expects that no server with the same `uuid` is already in the repository; if so, does nothing.
-     * @return true if the server was successfully added, false otherwise.
-     *              In particular, returns false if a server with the same uuid was already in the repository.
+     * @return true if the server was successfully added,
+     *         false if a server with the same uuid was already in the repository.
+     * @throws IOException if adding fails for any reason other than duplicate
      */
     fun addServer(minecraftServer: MinecraftServer): Boolean
 
@@ -45,6 +47,7 @@ interface MinecraftServerRepository {
      * Returns a [StateFlow] that always contains the up-to-date state of the server with uuid [uuid].
      * If the server is added or updated, the state flow will emit the new state.
      * If the server is removed, the state flow will emit `null`.
+     * If there is an issue with retrieving the server state, the flow will also emit `null`.
      */
     suspend fun getServerUpdates(uuid: UUID): StateFlow<MinecraftServer?>
 

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRunnerRepository.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/repository/MinecraftServerRunnerRepository.kt
@@ -1,11 +1,25 @@
 package com.rohengiralt.minecraftservermanager.domain.repository
 
 import com.rohengiralt.minecraftservermanager.domain.model.runner.MinecraftServerRunner
+import io.ktor.utils.io.errors.*
 import java.util.*
 
 interface MinecraftServerRunnerRepository {
+    /**
+     * Gets a runner by its UUID.
+     * @return a runner with UUID [uuid], or null if no runner exists with that UUID
+     */
     fun getRunner(uuid: UUID): MinecraftServerRunner?
+
+    /**
+     * Gets a runner by its name.
+     * @return a runner with name [name], or null if no runner exists with that name
+     */
     fun getRunner(name: String): MinecraftServerRunner?
 
+    /**
+     * Gets all the runners stored in this repository
+     * @throws IOException if retrieval fails
+     */
     fun getAllRunners(): List<MinecraftServerRunner>
 }

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/WebsocketAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/WebsocketAPIService.kt
@@ -36,13 +36,14 @@ interface WebsocketAPIService {
     suspend fun getServerUpdatesFlow(serverId: UUID): Flow<MinecraftServer?>
 
     /**
-     * Returns a flow for a that sends a new [List] of [MinecraftServerCurrentRun]s instance whenever the
+     * Returns a flow that sends a new [List] of [MinecraftServerCurrentRun]s whenever the
      * current runs of the server with UUID [serverId] change.
+     * @return a flow of current run updates, or `null` if the server or runner could not be retrieved.
      */
     suspend fun getAllCurrentRunsFlow(serverId: UUID): Flow<List<MinecraftServerCurrentRun>>?
 
     /**
-     * Returns a flow for a that sends a new [List] of [MinecraftServer]s whenever servers
+     * Returns a flow that sends a new [List] of [MinecraftServer]s whenever servers
      * are added or deleted.
      */
     suspend fun getAllServersUpdatesFlow(): Flow<List<MinecraftServer>>
@@ -78,7 +79,7 @@ class WebsocketAPIServiceImpl : WebsocketAPIService, KoinComponent {
         serverRepository.getServerUpdates(serverId)
 
     override suspend fun getAllCurrentRunsFlow(serverId: UUID): Flow<List<MinecraftServerCurrentRun>>? {
-        val server = serverRepository.getServer(serverId) ?: return null
+        val server = runCatching { serverRepository.getServer(serverId) }.getOrNull() ?: return null
         val runner = runnerRepository.getRunner(server.runnerUUID) ?: return null
 
         return runner.getAllCurrentRunsFlow(server)

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
@@ -32,15 +32,15 @@ interface RestAPIService {
     suspend fun updateServer(uuid: UUID, name: String? = null): APIResult<Unit>
     suspend fun deleteServer(uuid: UUID): APIResult<Unit>
 
-    suspend fun getAllRunners(): List<MinecraftServerRunner>
-    suspend fun getRunner(uuid: UUID): MinecraftServerRunner?
-    suspend fun getAllCurrentRuns(runnerUUID: UUID): List<MinecraftServerCurrentRun>?
-    suspend fun createCurrentRun(serverUUID: UUID, environment: MinecraftServerEnvironment): MinecraftServerCurrentRun?
-    suspend fun getCurrentRun(runnerUUID: UUID, runUUID: UUID): MinecraftServerCurrentRun?
-    suspend fun getCurrentRunByServer(serverUUID: UUID): MinecraftServerCurrentRun?
-    suspend fun stopCurrentRun(runnerUUID: UUID, runUUID: UUID): Boolean
-    suspend fun stopCurrentRunByServer(serverUUID: UUID): Boolean
-    suspend fun stopAllCurrentRuns(runnerUUID: UUID): Boolean
+    suspend fun getAllRunners(): APIResult<List<MinecraftServerRunner>>
+    suspend fun getRunner(uuid: UUID): APIResult<MinecraftServerRunner>
+    suspend fun getAllCurrentRuns(runnerUUID: UUID): APIResult<List<MinecraftServerCurrentRun>>
+    suspend fun createCurrentRun(serverUUID: UUID, environment: MinecraftServerEnvironment): APIResult<MinecraftServerCurrentRun>
+    suspend fun getCurrentRun(runnerUUID: UUID, runUUID: UUID): APIResult<MinecraftServerCurrentRun>
+    suspend fun getCurrentRunByServer(serverUUID: UUID): APIResult<MinecraftServerCurrentRun>
+    suspend fun stopCurrentRun(runnerUUID: UUID, runUUID: UUID): APIResult<Unit>
+    suspend fun stopCurrentRunByServer(serverUUID: UUID): APIResult<Unit>
+    suspend fun stopAllCurrentRuns(runnerUUID: UUID): APIResult<Unit>
 
     suspend fun getAllPastRuns(serverUUID: UUID): List<MinecraftServerPastRun>
     suspend fun getPastRun(serverUUID: UUID, runUUID: UUID): MinecraftServerPastRun?
@@ -80,9 +80,9 @@ interface RestAPIService {
              * Represents a failure due to the main resource not being found.
              * There should be at most one "main resource" in any API call.
              * For instance, the main resource of a `get*` method should be the resource attempting to be retrieved.
-             * @param resourceUUID the UUID of the resource not found.
+             * @param resourceUUID the UUID of the resource not found, or null if the resource's UUID is not known.
              */
-            data class MainResourceNotFound(val resourceUUID: UUID) : Failure
+            data class MainResourceNotFound(val resourceUUID: UUID?) : Failure
 
             /**
              * Represents a failure due to any resource other than the main one not being found.

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
@@ -28,9 +28,9 @@ interface RestAPIService {
     suspend fun getAllServers(): APIResult<List<MinecraftServer>>
     suspend fun createServer(uuid: UUID? = null, name: String, version: MinecraftVersion, runnerUUID: UUID): APIResult<MinecraftServer>
     suspend fun getServer(uuid: UUID): APIResult<MinecraftServer>
-    suspend fun setServer(uuid: UUID, name: String, version: MinecraftVersion, runnerUUID: UUID): Boolean
+    suspend fun setServer(uuid: UUID, name: String, version: MinecraftVersion, runnerUUID: UUID): APIResult<MinecraftServer>
     suspend fun updateServer(uuid: UUID, name: String? = null): APIResult<Unit>
-    suspend fun deleteServer(uuid: UUID): Boolean
+    suspend fun deleteServer(uuid: UUID): APIResult<Unit>
 
     suspend fun getAllRunners(): List<MinecraftServerRunner>
     suspend fun getRunner(uuid: UUID): MinecraftServerRunner?

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
@@ -26,7 +26,7 @@ import java.util.*
  */
 interface RestAPIService {
     suspend fun getAllServers(): APIResult<List<MinecraftServer>>
-    suspend fun createServer(uuid: UUID? = null, name: String, version: MinecraftVersion, runnerUUID: UUID): Boolean
+    suspend fun createServer(uuid: UUID? = null, name: String, version: MinecraftVersion, runnerUUID: UUID): APIResult<MinecraftServer>
     suspend fun getServer(uuid: UUID): APIResult<MinecraftServer>
     suspend fun setServer(uuid: UUID, name: String, version: MinecraftVersion, runnerUUID: UUID): Boolean
     suspend fun updateServer(uuid: UUID, name: String? = null): APIResult<Unit>
@@ -77,10 +77,23 @@ interface RestAPIService {
          */
         sealed interface Failure : APIResult<Nothing> {
             /**
-             * Represents a failure due to a resource not being found.
+             * Represents a failure due to the main resource not being found.
+             * There should be at most one "main resource" in any API call.
+             * For instance, the main resource of a `get*` method should be the resource attempting to be retrieved.
              * @param resourceUUID the UUID of the resource not found.
              */
-            data class NotFound(val resourceUUID: UUID) : Failure
+            data class MainResourceNotFound(val resourceUUID: UUID) : Failure
+
+            /**
+             * Represents a failure due to any resource other than the main one not being found.
+             * @param resourceUUID the UUID of the resource not found
+             */
+            data class AuxiliaryResourceNotFound(val resourceUUID: UUID) : Failure
+
+            /**
+             * Represents a failure due to attempting to create a resource that already exists
+             */
+            data class AlreadyExists(val resourceUUID: UUID) : Failure
 
             /**
              * Represents a failure for an unknown reason.

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
@@ -1,0 +1,100 @@
+package com.rohengiralt.minecraftservermanager.domain.service.rest
+
+import com.rohengiralt.minecraftservermanager.domain.model.run.MinecraftServerCurrentRun
+import com.rohengiralt.minecraftservermanager.domain.model.run.MinecraftServerPastRun
+import com.rohengiralt.minecraftservermanager.domain.model.runner.MinecraftServerRunner
+import com.rohengiralt.minecraftservermanager.domain.model.server.MinecraftServer
+import com.rohengiralt.minecraftservermanager.domain.model.server.MinecraftServerEnvironment
+import com.rohengiralt.minecraftservermanager.domain.model.server.MinecraftVersion
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult.Failure
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult.Success
+import com.rohengiralt.minecraftservermanager.user.UserLoginInfo
+import com.rohengiralt.minecraftservermanager.user.preferences.UserPreferences
+import io.ktor.server.application.*
+import io.ktor.util.pipeline.*
+import java.util.*
+
+/**
+ * An interface defining all the methods used by the Rest API.
+ * This interface provides a bridge between the domain and the frontend code
+ * directly handling client connections.
+ * The frontend should delegate immediately to an implementation of this interface.
+ *
+ * All methods in this interface should return a [APIResult],
+ * which can be relatively easily mapped into an HTTP response.
+ */
+interface RestAPIService {
+    suspend fun getAllServers(): APIResult<List<MinecraftServer>>
+    suspend fun createServer(uuid: UUID? = null, name: String, version: MinecraftVersion, runnerUUID: UUID): Boolean
+    suspend fun getServer(uuid: UUID): APIResult<MinecraftServer>
+    suspend fun setServer(uuid: UUID, name: String, version: MinecraftVersion, runnerUUID: UUID): Boolean
+    suspend fun updateServer(uuid: UUID, name: String? = null): APIResult<Unit>
+    suspend fun deleteServer(uuid: UUID): Boolean
+
+    suspend fun getAllRunners(): List<MinecraftServerRunner>
+    suspend fun getRunner(uuid: UUID): MinecraftServerRunner?
+    suspend fun getAllCurrentRuns(runnerUUID: UUID): List<MinecraftServerCurrentRun>?
+    suspend fun createCurrentRun(serverUUID: UUID, environment: MinecraftServerEnvironment): MinecraftServerCurrentRun?
+    suspend fun getCurrentRun(runnerUUID: UUID, runUUID: UUID): MinecraftServerCurrentRun?
+    suspend fun getCurrentRunByServer(serverUUID: UUID): MinecraftServerCurrentRun?
+    suspend fun stopCurrentRun(runnerUUID: UUID, runUUID: UUID): Boolean
+    suspend fun stopCurrentRunByServer(serverUUID: UUID): Boolean
+    suspend fun stopAllCurrentRuns(runnerUUID: UUID): Boolean
+
+    suspend fun getAllPastRuns(serverUUID: UUID): List<MinecraftServerPastRun>
+    suspend fun getPastRun(serverUUID: UUID, runUUID: UUID): MinecraftServerPastRun?
+
+    context(PipelineContext<*, ApplicationCall>)
+    suspend fun getCurrentUserLoginInfo(): UserLoginInfo?
+
+    context(PipelineContext<*, ApplicationCall>)
+    suspend fun deleteCurrentUser(): Boolean
+
+    context(PipelineContext<*, ApplicationCall>)
+    suspend fun getCurrentUserPreferences(): UserPreferences?
+    context(PipelineContext<*, ApplicationCall>)
+    suspend fun updateCurrentUserPreferences(sortStrategy: UserPreferences.SortStrategy? = null): Boolean
+
+    context(PipelineContext<*, ApplicationCall>)
+    suspend fun deleteCurrentUserPreferences(): Boolean
+
+    /**
+     * The result of an API action.
+     * May be either a [Success] or [Failure].
+     * Intended to be relatively easily mappable onto an HTTP response.
+     * @param T the type of the payload if successful
+     */
+    sealed interface APIResult<out T> {
+        /**
+         * Represents a successful execution of the action, potentially including some returned content.
+         * If an action does not intend to return additional content, it may return a `Success<Unit>`.
+         */
+        data class Success<T>(val content: T) : APIResult<T>
+
+        /**
+         * Represents an unsuccessful execution of the action.
+         */
+        sealed interface Failure : APIResult<Nothing> {
+            /**
+             * Represents a failure due to a resource not being found.
+             * @param resourceUUID the UUID of the resource not found.
+             */
+            data class NotFound(val resourceUUID: UUID) : Failure
+
+            /**
+             * Represents a failure for an unknown reason.
+             * @param exn optionally, the exception that caused the failure
+             */
+            data class Unknown(val exn: Exception? = null) : Failure
+        }
+
+        companion object {
+            /**
+             * Utility function for creating a `Success<Unit>`.
+             */
+            fun Success(): Success<Unit> = Success(Unit)
+        }
+    }
+}
+

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
@@ -43,7 +43,7 @@ interface RestAPIService {
     suspend fun stopAllCurrentRuns(runnerUUID: UUID): APIResult<Unit>
 
     suspend fun getAllPastRuns(serverUUID: UUID): APIResult<List<MinecraftServerPastRun>>
-    suspend fun getPastRun(serverUUID: UUID, runUUID: UUID): APIResult<MinecraftServerPastRun>
+    suspend fun getPastRun(runUUID: UUID): APIResult<MinecraftServerPastRun>
 
     context(PipelineContext<*, ApplicationCall>)
     suspend fun getCurrentUserLoginInfo(): UserLoginInfo?

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
@@ -45,19 +45,12 @@ interface RestAPIService {
     suspend fun getAllPastRuns(serverUUID: UUID): APIResult<List<MinecraftServerPastRun>>
     suspend fun getPastRun(runUUID: UUID): APIResult<MinecraftServerPastRun>
 
-    context(PipelineContext<*, ApplicationCall>)
-    suspend fun getCurrentUserLoginInfo(): UserLoginInfo?
+    context(API) suspend fun getCurrentUserLoginInfo(): APIResult<UserLoginInfo>
+    context(API) suspend fun deleteCurrentUser(): APIResult<Unit>
 
-    context(PipelineContext<*, ApplicationCall>)
-    suspend fun deleteCurrentUser(): Boolean
-
-    context(PipelineContext<*, ApplicationCall>)
-    suspend fun getCurrentUserPreferences(): UserPreferences?
-    context(PipelineContext<*, ApplicationCall>)
-    suspend fun updateCurrentUserPreferences(sortStrategy: UserPreferences.SortStrategy? = null): Boolean
-
-    context(PipelineContext<*, ApplicationCall>)
-    suspend fun deleteCurrentUserPreferences(): Boolean
+    context(API) suspend fun getCurrentUserPreferences(): APIResult<UserPreferences>
+    context(API) suspend fun updateCurrentUserPreferences(sortStrategy: UserPreferences.SortStrategy? = null): APIResult<Unit>
+    context(API) suspend fun deleteCurrentUserPreferences(): APIResult<Unit>
 
     /**
      * The result of an API action.
@@ -96,6 +89,12 @@ interface RestAPIService {
             data class AlreadyExists(val resourceUUID: UUID) : Failure
 
             /**
+             * Represents a failure due to a parameter with the correct type but invalid value.
+             * For instance, a negative number when a positive integer is required
+             */
+            data class InvalidValue(val value: Any?) : Failure
+
+            /**
              * Represents a failure for an unknown reason.
              * @param exn optionally, the exception that caused the failure
              */
@@ -111,3 +110,4 @@ interface RestAPIService {
     }
 }
 
+private typealias API = PipelineContext<*, ApplicationCall>

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIService.kt
@@ -42,8 +42,8 @@ interface RestAPIService {
     suspend fun stopCurrentRunByServer(serverUUID: UUID): APIResult<Unit>
     suspend fun stopAllCurrentRuns(runnerUUID: UUID): APIResult<Unit>
 
-    suspend fun getAllPastRuns(serverUUID: UUID): List<MinecraftServerPastRun>
-    suspend fun getPastRun(serverUUID: UUID, runUUID: UUID): MinecraftServerPastRun?
+    suspend fun getAllPastRuns(serverUUID: UUID): APIResult<List<MinecraftServerPastRun>>
+    suspend fun getPastRun(serverUUID: UUID, runUUID: UUID): APIResult<MinecraftServerPastRun>
 
     context(PipelineContext<*, ApplicationCall>)
     suspend fun getCurrentUserLoginInfo(): UserLoginInfo?

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIServiceImpl.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIServiceImpl.kt
@@ -48,11 +48,12 @@ class RestAPIServiceImpl : RestAPIService, KoinComponent {
 
         runner.initializeServer(server).ifFalse { return Failure.Unknown() }
 
-        val addSuccess = serverRepository.addServer(server)
+        val addSuccess = runCatching { serverRepository.addServer(server) }.getOrElse { false }
         if (addSuccess) {
             return Success(server)
         } else {
-            runner.removeServer(server)
+            runCatching { runner.removeServer(server) }
+                .getOrElse { false }
                 .ifFalse { logger.warn("Failed to clean up resources for ${server.uuid} persistence failure.") }
 
             return Failure.AlreadyExists(server.uuid)

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIServiceImpl.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIServiceImpl.kt
@@ -24,7 +24,6 @@ import com.rohengiralt.minecraftservermanager.util.ifTrue.ifFalse
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.util.pipeline.*
-import io.ktor.utils.io.errors.*
 import kotlinx.datetime.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -61,13 +60,9 @@ class RestAPIServiceImpl : RestAPIService, KoinComponent {
     }
 
     override suspend fun getServer(uuid: UUID): APIResult<MinecraftServer> =
-        try {
-            serverRepository.getServer(uuid)
-                ?.let { Success(it) }
-                ?: Failure.MainResourceNotFound(uuid)
-        } catch (e: IOException) {
-            Failure.Unknown(e)
-        }
+        serverRepository.getServer(uuid)
+            ?.let { Success(it) }
+            ?: Failure.MainResourceNotFound(uuid)
 
     override suspend fun setServer(uuid: UUID, name: String, version: MinecraftVersion, runnerUUID: UUID): APIResult<MinecraftServer> {
         val newServer = MinecraftServer(

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIServiceImpl.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/domain/service/rest/RestAPIServiceImpl.kt
@@ -199,11 +199,11 @@ class RestAPIServiceImpl : RestAPIService, KoinComponent {
         return if (stopSuccess) Success() else Failure.Unknown()
     }
 
-    override suspend fun getAllPastRuns(serverUUID: UUID): List<MinecraftServerPastRun> =
-        pastRunRepository.getAllPastRuns(serverUUID)
+    override suspend fun getAllPastRuns(serverUUID: UUID): APIResult<List<MinecraftServerPastRun>> =
+        pastRunRepository.getAllPastRuns(serverUUID).let(::Success)
 
-    override suspend fun getPastRun(serverUUID: UUID, runUUID: UUID): MinecraftServerPastRun? =
-        pastRunRepository.getPastRun(runUUID)
+    override suspend fun getPastRun(runUUID: UUID): APIResult<MinecraftServerPastRun> =
+        pastRunRepository.getPastRun(runUUID)?.let(::Success) ?: Failure.MainResourceNotFound(runUUID)
 
     context(PipelineContext<*, ApplicationCall>)
     override suspend fun getCurrentUserLoginInfo(): UserLoginInfo? = call.principal<UserLoginInfo>()

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
@@ -3,12 +3,16 @@ package com.rohengiralt.minecraftservermanager.frontend.routes
 import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult
 import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult.Failure
 import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult.Success
+import com.rohengiralt.minecraftservermanager.plugins.ConflictException
 import com.rohengiralt.minecraftservermanager.plugins.InternalServerException
+import io.ktor.server.application.*
 import io.ktor.server.plugins.*
+import io.ktor.util.pipeline.*
 import javax.annotation.CheckReturnValue
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
+context(PipelineContext<*, ApplicationCall>)
 @CheckReturnValue
 @OptIn(ExperimentalContracts::class)
 fun <T> APIResult<T>.orThrow(): T {
@@ -19,6 +23,8 @@ fun <T> APIResult<T>.orThrow(): T {
     return when (this) {
         is Success -> content
         is Failure.Unknown -> throw InternalServerException()
-        is Failure.NotFound -> throw NotFoundException()
+        is Failure.MainResourceNotFound -> throw NotFoundException("Could not find $resourceUUID")
+        is Failure.AuxiliaryResourceNotFound -> throw BadRequestException("Missing parameter $resourceUUID")
+        is Failure.AlreadyExists -> throw ConflictException()
     }
 }

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
@@ -1,0 +1,24 @@
+package com.rohengiralt.minecraftservermanager.frontend.routes
+
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult.Failure
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult.Success
+import com.rohengiralt.minecraftservermanager.plugins.InternalServerException
+import io.ktor.server.plugins.*
+import javax.annotation.CheckReturnValue
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@CheckReturnValue
+@OptIn(ExperimentalContracts::class)
+fun <T> APIResult<T>.orThrow(): T {
+    contract {
+        returns() implies (this@orThrow is Success)
+    }
+
+    return when (this) {
+        is Success -> content
+        is Failure.Unknown -> throw InternalServerException()
+        is Failure.NotFound -> throw NotFoundException()
+    }
+}

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
@@ -5,10 +5,7 @@ import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService.APIResult.Success
 import com.rohengiralt.minecraftservermanager.plugins.ConflictException
 import com.rohengiralt.minecraftservermanager.plugins.InternalServerException
-import io.ktor.server.application.*
 import io.ktor.server.plugins.*
-import io.ktor.util.pipeline.*
-import javax.annotation.CheckReturnValue
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -17,8 +14,6 @@ import kotlin.contracts.contract
  * Returns the content of a successful [APIResult],
  * or throws an appropriate HTTP Exception on [Failure].
  */
-context(PipelineContext<*, ApplicationCall>)
-@CheckReturnValue
 @OptIn(ExperimentalContracts::class)
 fun <T> APIResult<T>.orThrow(): T {
     contract {

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/ErrorHandling.kt
@@ -10,8 +10,13 @@ import io.ktor.server.plugins.*
 import io.ktor.util.pipeline.*
 import javax.annotation.CheckReturnValue
 import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+/**
+ * Returns the content of a successful [APIResult],
+ * or throws an appropriate HTTP Exception on [Failure].
+ */
 context(PipelineContext<*, ApplicationCall>)
 @CheckReturnValue
 @OptIn(ExperimentalContracts::class)
@@ -23,8 +28,24 @@ fun <T> APIResult<T>.orThrow(): T {
     return when (this) {
         is Success -> content
         is Failure.Unknown -> throw InternalServerException()
-        is Failure.MainResourceNotFound -> throw NotFoundException("Could not find $resourceUUID")
+        is Failure.MainResourceNotFound -> throw NotFoundException("Could not find ${resourceUUID ?: "the requested resource"}")
         is Failure.AuxiliaryResourceNotFound -> throw BadRequestException("Missing parameter $resourceUUID")
         is Failure.AlreadyExists -> throw ConflictException()
+    }
+}
+
+/**
+ * Returns the content of a successful [APIResult],
+ * or returns the value of executing [block] on [Failure].
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <T> APIResult<T>.orElse(block: (Failure) -> T): T {
+    contract {
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Success -> this.content
+        is Failure -> block(this)
     }
 }

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/WebsocketRoute.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/WebsocketRoute.kt
@@ -36,7 +36,7 @@ fun Route.websockets() {
                     ?: return@coroutineScope close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, "Could not parse server UUID"))
 
                 val currentRunsFlow = websocketAPIService.getAllCurrentRunsFlow(serverUUID)
-                    ?: return@coroutineScope close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, "Could not find server with UUID $serverUUID"))
+                    ?: return@coroutineScope close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, "Could not find runs for server with UUID $serverUUID"))
 
                 call.application.environment.log.debug(
                     "Opening current runs updates websocket for server {}",

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Servers.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Servers.kt
@@ -1,9 +1,10 @@
 package com.rohengiralt.minecraftservermanager.frontend.routes.rest
 
-import com.rohengiralt.minecraftservermanager.domain.service.RestAPIService
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerAPIModel
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerCurrentRunAPIModel
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerEnvironmentAPIModel
+import com.rohengiralt.minecraftservermanager.frontend.routes.orThrow
 import com.rohengiralt.minecraftservermanager.plugins.ConflictException
 import com.rohengiralt.minecraftservermanager.plugins.NotAllowedException
 import com.rohengiralt.minecraftservermanager.util.routes.*
@@ -19,7 +20,7 @@ fun Route.serversRoute() { // TODO: Better response codes in general
 
     get {
         call.application.environment.log.info("Getting all servers")
-        call.respond(restApiService.getAllServers().map(::MinecraftServerAPIModel))
+        call.respond(restApiService.getAllServers().orThrow().map(::MinecraftServerAPIModel))
     }
 
     post {
@@ -55,9 +56,7 @@ fun Route.serversRoute() { // TODO: Better response codes in general
             val serverUUID = call.getParameterOrBadRequest("id").parseUUIDOrBadRequest()
 
             call.respond(
-                restApiService.getServer(uuid = serverUUID)
-                    ?.let(::MinecraftServerAPIModel)
-                    ?: throw NotFoundException()
+                restApiService.getServer(uuid = serverUUID).orThrow().let(::MinecraftServerAPIModel)
             )
         }
 
@@ -71,16 +70,10 @@ fun Route.serversRoute() { // TODO: Better response codes in general
             if (serverAPIModel.version != null) cannotUpdateField("version")
             if (serverAPIModel.runnerUUID != null) cannotUpdateField("runnerUUID")
 
-            val success = restApiService.updateServer(
+            restApiService.updateServer(
                 uuid = serverUUID,
                 name = serverAPIModel.name,
-            )
-
-            if (success) {
-                call.respond(HttpStatusCode.OK)
-            } else {
-                call.respond(HttpStatusCode.NotFound)
-            }
+            ).orThrow()
         }
 
         put {

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Servers.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Servers.kt
@@ -82,31 +82,21 @@ fun Route.serversRoute() { // TODO: Better response codes in general
             val version = serverAPIModel.version ?: missingField("version")
             val runnerUUID = serverAPIModel.runnerUUID ?: missingField("runnerUUID")
 
-            val success = restApiService.setServer(
+            val newServer = restApiService.setServer(
                 uuid = uuid,
                 name = name,
                 version = version,
                 runnerUUID = runnerUUID,
-            )
+            ).orThrow()
 
-            if (success) {
-                call.respond(HttpStatusCode.OK)
-            } else {
-                call.respond(HttpStatusCode.InternalServerError)
-            }
+            call.respond(HttpStatusCode.OK, newServer.let(::MinecraftServerAPIModel))
         }
 
         delete {
             call.application.environment.log.info("Deleting server with id ${call.parameters["id"]}")
             val uuid = call.getParameterOrBadRequest("id").parseUUIDOrBadRequest()
 
-            val success = restApiService.deleteServer(uuid)
-
-            if (success) {
-                call.respond(HttpStatusCode.OK)
-            } else {
-                call.respond(HttpStatusCode.NotFound) // TODO: could also be 500 if server failed to delete
-            }
+            restApiService.deleteServer(uuid).orThrow()
         }
 
         route("/currentRun") {

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Servers.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Servers.kt
@@ -5,7 +5,6 @@ import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerAPIM
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerCurrentRunAPIModel
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerEnvironmentAPIModel
 import com.rohengiralt.minecraftservermanager.frontend.routes.orThrow
-import com.rohengiralt.minecraftservermanager.plugins.ConflictException
 import com.rohengiralt.minecraftservermanager.plugins.NotAllowedException
 import com.rohengiralt.minecraftservermanager.util.routes.*
 import io.ktor.http.*
@@ -35,15 +34,11 @@ fun Route.serversRoute() { // TODO: Better response codes in general
         val version = serverAPIModel.version ?: missingField("version")
         val runnerUUID = serverAPIModel.runnerUUID ?: missingField("runnerUUID")
 
-        val success = restApiService.createServer(
+        val newServer = restApiService.createServer(
             uuid = null, name = name, version = version, runnerUUID = runnerUUID
-        )
+        ).orThrow()
 
-        if (success) {
-            call.respond(HttpStatusCode.Created) // TODO: Respond with the server added (?)
-        } else {
-            throw ConflictException()
-        }
+        call.respond(HttpStatusCode.Created, newServer.let(::MinecraftServerAPIModel))
     }
 
     delete {

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Users.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Users.kt
@@ -1,6 +1,6 @@
 package com.rohengiralt.minecraftservermanager.frontend.routes.rest
 
-import com.rohengiralt.minecraftservermanager.domain.service.RestAPIService
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.UserLoginInfoAPIModel
 import com.rohengiralt.minecraftservermanager.frontend.model.UserPreferencesAPIModel
 import com.rohengiralt.minecraftservermanager.plugins.AuthorizationException

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Users.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/Users.kt
@@ -3,13 +3,12 @@ package com.rohengiralt.minecraftservermanager.frontend.routes.rest
 import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.UserLoginInfoAPIModel
 import com.rohengiralt.minecraftservermanager.frontend.model.UserPreferencesAPIModel
-import com.rohengiralt.minecraftservermanager.plugins.AuthorizationException
+import com.rohengiralt.minecraftservermanager.frontend.routes.orThrow
 import com.rohengiralt.minecraftservermanager.user.UserLoginInfo
 import com.rohengiralt.minecraftservermanager.util.routes.receiveSerializable
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.koin.ktor.ext.inject
@@ -20,21 +19,17 @@ fun Route.usersRoute() {
 
         get {
             call.application.environment.log.info("Getting user login info with id ${call.principal<UserLoginInfo>()?.userId}")
-            val user = restApiService.getCurrentUserLoginInfo() ?: throw AuthorizationException()
+            val user = restApiService.getCurrentUserLoginInfo().orThrow()
 
             call.respond(UserLoginInfoAPIModel(user))
         }
 
         delete {
             call.application.environment.log.info("Deleting user with id: ${call.principal<UserLoginInfo>()?.userId}")
-            val userInfoDeletionSuccess = restApiService.deleteCurrentUser()
-            val userPreferencesDeletionSuccess = restApiService.deleteCurrentUserPreferences()
+            restApiService.deleteCurrentUser().orThrow()
+            restApiService.deleteCurrentUserPreferences().orThrow()
 
-            if (userInfoDeletionSuccess && userPreferencesDeletionSuccess) {
-                call.respond(HttpStatusCode.NoContent)
-            } else {
-                call.respond(HttpStatusCode.InternalServerError)
-            }
+            call.respond(HttpStatusCode.OK)
         }
 
         route("/preferences") {
@@ -42,9 +37,8 @@ fun Route.usersRoute() {
                 call.application.environment.log.info("Getting user preferences for user with id ${call.principal<UserLoginInfo>()?.userId}")
 
                 val preferences = restApiService
-                    .getCurrentUserPreferences()
-                    ?.let(::UserPreferencesAPIModel)
-                    ?: throw NotFoundException()
+                    .getCurrentUserPreferences().orThrow()
+                    .let(::UserPreferencesAPIModel)
 
                 call.respond(preferences)
             }
@@ -53,15 +47,11 @@ fun Route.usersRoute() {
                 call.application.environment.log.info("Patching user preferences for user with id ${call.principal<UserLoginInfo>()?.userId}")
                 val userPreferencesAPIModel: UserPreferencesAPIModel = call.receiveSerializable()
 
-                val success = restApiService.updateCurrentUserPreferences(
+                restApiService.updateCurrentUserPreferences(
                     sortStrategy = userPreferencesAPIModel.serverSortStrategy,
-                )
+                ).orThrow()
 
-                if (success) {
-                    call.respond(HttpStatusCode.NoContent)
-                } else {
-                    call.respond(HttpStatusCode.NotFound)
-                }
+                call.respond(HttpStatusCode.OK)
             }
         }
     }

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/CurrentRuns.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/CurrentRuns.kt
@@ -1,6 +1,6 @@
 package com.rohengiralt.minecraftservermanager.frontend.routes.rest.runners
 
-import com.rohengiralt.minecraftservermanager.domain.service.RestAPIService
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerCurrentRunAPIModel
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerEnvironmentAPIModel
 import com.rohengiralt.minecraftservermanager.plugins.NotAllowedException

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/PastRuns.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/PastRuns.kt
@@ -2,11 +2,11 @@ package com.rohengiralt.minecraftservermanager.frontend.routes.rest.runners
 
 import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerPastRunAPIModel
+import com.rohengiralt.minecraftservermanager.frontend.routes.orThrow
 import com.rohengiralt.minecraftservermanager.plugins.NotAllowedException
 import com.rohengiralt.minecraftservermanager.util.routes.getParameterOrBadRequest
 import com.rohengiralt.minecraftservermanager.util.routes.parseUUIDOrBadRequest
 import io.ktor.server.application.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.koin.ktor.ext.inject
@@ -18,19 +18,17 @@ fun Route.pastRuns() {
         call.application.environment.log.info("Getting all past runs")
         val serverUUID = call.getParameterOrBadRequest("serverId").parseUUIDOrBadRequest()
 
-        call.respond(restApiService.getAllPastRuns(serverUUID).map(::MinecraftServerPastRunAPIModel))
+        call.respond(restApiService.getAllPastRuns(serverUUID).orThrow().map(::MinecraftServerPastRunAPIModel))
     }
 
     route("/{runId}") {
         get {
-            val serverUUID = call.getParameterOrBadRequest("serverId").parseUUIDOrBadRequest()
             val runUUID = call.getParameterOrBadRequest("runId").parseUUIDOrBadRequest()
 
             call.respond(
                 restApiService
-                    .getPastRun(serverUUID = serverUUID, runUUID = runUUID)
-                    ?.let(::MinecraftServerPastRunAPIModel)
-                    ?: throw NotFoundException()
+                    .getPastRun(runUUID = runUUID).orThrow()
+                    .let(::MinecraftServerPastRunAPIModel)
             )
         }
 

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/PastRuns.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/PastRuns.kt
@@ -1,6 +1,6 @@
 package com.rohengiralt.minecraftservermanager.frontend.routes.rest.runners
 
-import com.rohengiralt.minecraftservermanager.domain.service.RestAPIService
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerPastRunAPIModel
 import com.rohengiralt.minecraftservermanager.plugins.NotAllowedException
 import com.rohengiralt.minecraftservermanager.util.routes.getParameterOrBadRequest

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/Runners.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/Runners.kt
@@ -1,6 +1,6 @@
 package com.rohengiralt.minecraftservermanager.frontend.routes.rest.runners
 
-import com.rohengiralt.minecraftservermanager.domain.service.RestAPIService
+import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerRunnerAPIModel
 import com.rohengiralt.minecraftservermanager.plugins.NotAllowedException
 import com.rohengiralt.minecraftservermanager.util.routes.getParameterOrBadRequest

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/Runners.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/frontend/routes/rest/runners/Runners.kt
@@ -2,11 +2,11 @@ package com.rohengiralt.minecraftservermanager.frontend.routes.rest.runners
 
 import com.rohengiralt.minecraftservermanager.domain.service.rest.RestAPIService
 import com.rohengiralt.minecraftservermanager.frontend.model.MinecraftServerRunnerAPIModel
+import com.rohengiralt.minecraftservermanager.frontend.routes.orThrow
 import com.rohengiralt.minecraftservermanager.plugins.NotAllowedException
 import com.rohengiralt.minecraftservermanager.util.routes.getParameterOrBadRequest
 import com.rohengiralt.minecraftservermanager.util.routes.parseUUIDOrBadRequest
 import io.ktor.server.application.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.koin.ktor.ext.inject
@@ -15,7 +15,7 @@ fun Route.runnersRoute() {
     val restApiService: RestAPIService by this@runnersRoute.inject()
     get {
         call.application.environment.log.info("Getting all runners")
-        call.respond(restApiService.getAllRunners().map(::MinecraftServerRunnerAPIModel))
+        call.respond(restApiService.getAllRunners().orThrow().map(::MinecraftServerRunnerAPIModel))
     }
 
     delete {
@@ -28,7 +28,7 @@ fun Route.runnersRoute() {
             val runnerUUID = call.getParameterOrBadRequest("runnerId").parseUUIDOrBadRequest()
 
             call.respond(
-                restApiService.getRunner(runnerUUID)?.let(::MinecraftServerRunnerAPIModel) ?: throw NotFoundException()
+                restApiService.getRunner(runnerUUID).orThrow().let(::MinecraftServerRunnerAPIModel)
             )
         }
 

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/util/sql/IOExnTransaction.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/util/sql/IOExnTransaction.kt
@@ -1,0 +1,17 @@
+package com.rohengiralt.minecraftservermanager.util.sql
+
+import io.ktor.utils.io.errors.*
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.sql.SQLException
+
+/**
+ * Executes a transaction in which any uncaught [SQLException]s are converted into [IOException]s.
+ * Useful when it's not desirable to propagate a [SQLException].
+ */
+fun <T> ioExnTransaction(statement: Transaction.() -> T): T =
+    try {
+        transaction(null, statement)
+    } catch (e: SQLException) {
+        throw IOException(e)
+    }

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/util/sql/SafeSQLState.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/util/sql/SafeSQLState.kt
@@ -1,0 +1,11 @@
+package com.rohengiralt.minecraftservermanager.util.sql
+
+import java.sql.SQLException
+
+val SQLException.state: SQLState
+    get() = SQLState.entries.firstOrNull { it.code == sqlState } ?: SQLState.OTHER
+
+enum class SQLState(val code: String?) {
+    UNIQUE_VIOLATION("23505"),
+    OTHER(null);
+}

--- a/src/main/kotlin/com/rohengiralt/minecraftservermanager/util/sql/SafeSQLState.kt
+++ b/src/main/kotlin/com/rohengiralt/minecraftservermanager/util/sql/SafeSQLState.kt
@@ -2,9 +2,16 @@ package com.rohengiralt.minecraftservermanager.util.sql
 
 import java.sql.SQLException
 
+/**
+ * A typesafe representation of this exception's [SQLException.SQLState]
+ */
 val SQLException.state: SQLState
     get() = SQLState.entries.firstOrNull { it.code == sqlState } ?: SQLState.OTHER
 
+/**
+ * Recognized SQL state responses.
+ * May be Postgres-specific.
+ */
 enum class SQLState(val code: String?) {
     UNIQUE_VIOLATION("23505"),
     OTHER(null);


### PR DESCRIPTION
Introduces the `APIResult` class, used as the return value of all methods in `RestAPIService`.

Prior to this change, request failures were represented only by `null` or `false`, which was often not rich enough to allow a specific HTTP response code. For instance, `createServer` might fail because the specified runner does not exist, because the server already exists, or because the runner fails to allocate resources (and more!). Those failure modes would require an HTTP 400, HTTP 409, or HTTP 500, respectively. `APIResult` now provides more specific failure responses, allowing these events to be disambiguated.

As part of this PR, some lower level classes (mainly repositories) had their signatures slightly changed in order to provide sufficient information for an accurate `APIResult` response. However, because `APIResult` is intended to be used only in the REST layer, the additional information in these cases was largely provided by exceptions.